### PR TITLE
New Email object and retrieval method

### DIFF
--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -30,6 +30,20 @@ module WatirmarkEmail
       end
     end
 
+    def search_hash_to_array (hash_of_search_params)
+      converted_array = Array.new
+      hash_of_search_params.each do | search_key, search_value |
+        converted_array = converted_array + search_element_array(search_key.to_s.upcase, search_value.to_s)
+      end
+    end
+
+    def search_element_array (key_string, value)
+      result_array = Array.new
+      first, *rest = *value
+      result_array.concat [key_string, first]
+      result_array + search_element_array(key_string, rest) unless rest.empty?
+    end
+
     def get_email_text(search_array, timeout=600, delete=true, since_sec=3600)
       # Trying super ugly workaraound for the gmail 'Too many simlutaneous connections' error.
       # Just trying to login to gmail and if it fails try to wait until other connections

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -64,6 +64,7 @@ module WatirmarkEmail
     end
 
     def search_hash_to_array (hash_of_search_params)
+      raise "Parameter given is not a hash" unless hash_of_search_params.class == Hash
       converted_array = Array.new
       hash_of_search_params.each do | search_key, search_value |
         converted_array = converted_array + search_elements_array(search_key.to_s.upcase, search_value.to_s)

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -66,15 +66,17 @@ module WatirmarkEmail
     def search_hash_to_array (hash_of_search_params)
       converted_array = Array.new
       hash_of_search_params.each do | search_key, search_value |
-        converted_array = converted_array + search_element_array(search_key.to_s.upcase, search_value.to_s)
+        converted_array = converted_array + search_elements_array(search_key.to_s.upcase, search_value.to_s)
       end
+      converted_array
     end
 
-    def search_element_array (key_string, value)
+    def search_elements_array (key_string, value)
       result_array = Array.new
       first, *rest = *value
       result_array.concat [key_string, first]
-      result_array + search_element_array(key_string, rest) unless rest.empty?
+      result_array = result_array + search_elements_array(key_string, rest) unless rest.empty?
+      result_array
     end
 
     def get_email_text(search_array, timeout=600, delete=true, since_sec=3600)

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -55,7 +55,7 @@ module WatirmarkEmail
             end
             disconnect(imap) unless imap.nil? # because sometimes the timeout happens before imap is defined
           end
-          break if break if email.has_envelope?
+          break if email.has_envelope?
           @log.debug("Couldn't find email yet ... trying again")
           sleep 10
         end

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -44,7 +44,7 @@ module WatirmarkEmail
               email.uid = imap.fetch(email.message_id , 'UID').last.attr['UID']
               email.envelope = imap.uid_fetch(email.uid , 'ENVELOPE').last.attr['ENVELOPE']
               email.body_text = imap.uid_fetch(email.uid , 'BODY[TEXT]').last.attr['BODY[TEXT]']
-              email.body_raw = imap.uid_fetch(email.uid , 'BODY[]').last.atter['BODY[]']
+              email.body_raw = imap.uid_fetch(email.uid , 'BODY[]').last.attr['BODY[]']
             end
           rescue => e
             @log.info("Error connecting to IMAP: #{e.message}")

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -42,9 +42,9 @@ module WatirmarkEmail
             if msgs.size > 0
               email.message_id = msgs.last
               email.uid = imap.fetch(email.message_id , 'UID').last.attr['UID']
+              email.envelope = imap.uid_fetch(email.uid , 'ENVELOPE').last.attr['ENVELOPE']
               email.body_text = imap.uid_fetch(email.uid , 'BODY[TEXT]').last.attr['BODY[TEXT]']
               email.body_raw = imap.uid_fetch(email.uid , 'BODY[]').last.atter['BODY[]']
-              email.envelope = imap.uid_fetch(email.uid , 'ENVELOPE').last.attr['ENVELOPE']
             end
           rescue => e
             @log.info("Error connecting to IMAP: #{e.message}")

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -30,7 +30,7 @@ module WatirmarkEmail
       end
     end
 
-    def get_email(search_hash, timeout=600, delete=true, since_sec=3600)
+    def get_email(search_hash, timeout=600, delete=true)
       email = Email.new
       ::Timeout.timeout(timeout) do
         @log.debug("start Timeout block for #{timeout} seconds")

--- a/lib/watirmark_email/email_base.rb
+++ b/lib/watirmark_email/email_base.rb
@@ -49,13 +49,13 @@ module WatirmarkEmail
           rescue => e
             @log.info("Error connecting to IMAP: #{e.message}")
           ensure
-            if (delete && email.uid)
+            if delete && email.uid
               @log.info("Deleting the email message #{email.subject}")
               delete(email.uid, imap)
             end
             disconnect(imap) unless imap.nil? # because sometimes the timeout happens before imap is defined
           end
-          break if (!email.nil? && email.body_text)
+          break if break if email.has_envelope?
           @log.debug("Couldn't find email yet ... trying again")
           sleep 10
         end

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -19,9 +19,8 @@ module WatirmarkEmail
     end
 
     def to
-      @to||= envelope.to.each do |recipient|
-        @to||= Array.new
-        @to << "#{recipient.mailbox}@#{recipient.host}"
+      @to||= envelope.to.each_with_object([]) do |recipient, to_array|
+        to_array << "#{recipient.mailbox}@#{recipient.host}"
       end
     end
 

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -1,6 +1,6 @@
 module WatirmarkEmail
   class Email
-    attr_accessor :date, :subject, :to, :from, :message_id, :body_text, :body_raw, :uid, :envelope
+    attr_accessor :date, :subject, :to, :reply_to, :from, :message_id, :body_text, :body_raw, :uid, :envelope
 
     def subject
       @subject ||= envelope.subject
@@ -22,6 +22,10 @@ module WatirmarkEmail
       @to ||= envelope.to.each_with_object([]) do |recipient, to_array|
         to_array << "#{recipient.mailbox}@#{recipient.host}"
       end
+    end
+
+    def reply_to
+      @reply_to ||= "#{envelope.reply_to.first.name} <#{envelope.reply_to.first.mailbox}@#{envelope.reply_to.first.host}>"
     end
 
     def <=> (other)

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -40,15 +40,15 @@ module WatirmarkEmail
     end
 
     def bccs
-      @bccs ||=  envelope.bcc.each_with_object([]) do |bcc_user, bccs_array|
+      @bccs ||= envelope.bcc ? envelope.bcc.each_with_object([]) do |bcc_user, bccs_array|
         bccs_array <<  "#{bcc_user.name} <#{bcc_user.mailbox}@#{bcc_user.host}>"
-      end
+      end : Array.new
     end
 
     def ccs
-      @ccs ||=  envelope.cc.each_with_object([]) do |cc_user, ccs_array|
+      @ccs ||= envelope.cc ? envelope.cc.each_with_object([]) do |cc_user, ccs_array|
         ccs_array <<  "#{cc_user.name} <#{cc_user.mailbox}@#{cc_user.host}>"
-      end
+      end : Array.new
     end
 
     def in_reply_to

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -1,6 +1,7 @@
 module WatirmarkEmail
   class Email
-    attr_accessor :date, :subject, :to, :reply_to, :from, :message_id, :body_text, :body_raw, :uid, :envelope
+    attr_accessor :date, :subject, :in_reply_to, :message_id, :body_text, :body_raw, :uid, :envelope,
+                  :tos, :reply_tos, :froms, :senders, :ccs, :bccs
 
     def subject
       @subject ||= envelope.subject
@@ -14,19 +15,9 @@ module WatirmarkEmail
       @message_id ||= envelope.message_id
     end
 
-    def from
-      @from ||= "#{envelope.from.first.mailbox}@#{envelope.from.first.host}"
-    end
-
     def froms
       @froms  ||= envelope.from.each_with_object([]) do |from_user, froms_array|
         froms_array << "#{from_user.mailbox}@#{from_user.host}"
-      end
-    end
-
-    def to
-      @to ||= envelope.to.each_with_object([]) do |recipient, to_array|
-        to_array << "#{recipient.mailbox}@#{recipient.host}"
       end
     end
 
@@ -34,10 +25,6 @@ module WatirmarkEmail
       @tos ||= envelope.to.each_with_object([]) do |recipient, tos_array|
         tos_array << "#{recipient.mailbox}@#{recipient.host}"
       end
-    end
-
-    def reply_to
-      @reply_to ||= "#{envelope.reply_to.first.name} <#{envelope.reply_to.first.mailbox}@#{envelope.reply_to.first.host}>"
     end
 
     def reply_tos

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -27,6 +27,10 @@ module WatirmarkEmail
     def <=> (other)
       date <=> other.date
     end
+
+    def has_envelope?
+      not envelope.nil?
+    end
   end
 
   class EmailCollection

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -3,23 +3,23 @@ module WatirmarkEmail
     attr_accessor :date, :subject, :to, :from, :message_id, :body_text, :body_raw, :uid, :envelope
 
     def subject
-      @subject||= envelope.subject
+      @subject ||= envelope.subject
     end
 
     def date
-      @date||= envelope.date
+      @date ||= envelope.date
     end
 
     def message_id
-      @message_id||= envelope.message_id
+      @message_id ||= envelope.message_id
     end
 
     def from
-      @from||= "#{envelope.from.first.mailbox}@#{envelope.from.first.host}"
+      @from ||= "#{envelope.from.first.mailbox}@#{envelope.from.first.host}"
     end
 
     def to
-      @to||= envelope.to.each_with_object([]) do |recipient, to_array|
+      @to ||= envelope.to.each_with_object([]) do |recipient, to_array|
         to_array << "#{recipient.mailbox}@#{recipient.host}"
       end
     end

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -18,14 +18,54 @@ module WatirmarkEmail
       @from ||= "#{envelope.from.first.mailbox}@#{envelope.from.first.host}"
     end
 
+    def froms
+      @froms  ||= envelope.from.each_with_object([]) do |from_user, froms_array|
+        froms_array << "#{from_user.mailbox}@#{from_user.host}"
+      end
+    end
+
     def to
       @to ||= envelope.to.each_with_object([]) do |recipient, to_array|
         to_array << "#{recipient.mailbox}@#{recipient.host}"
       end
     end
 
+    def tos
+      @tos ||= envelope.to.each_with_object([]) do |recipient, tos_array|
+        tos_array << "#{recipient.mailbox}@#{recipient.host}"
+      end
+    end
+
     def reply_to
       @reply_to ||= "#{envelope.reply_to.first.name} <#{envelope.reply_to.first.mailbox}@#{envelope.reply_to.first.host}>"
+    end
+
+    def reply_tos
+        @reply_tos ||= envelope.reply_to.each_with_object([]) do |reply_to_user, reply_tos_array|
+          reply_tos_array <<  "#{reply_to_user.name} <#{reply_to_user.mailbox}@#{reply_to_user.host}>"
+        end
+    end
+
+    def senders
+      @senders ||=  envelope.sender.each_with_object([]) do |sender_user, senders_array|
+        senders_array <<  "#{sender_user.name} <#{sender_user.mailbox}@#{sender_user.host}>"
+      end
+    end
+
+    def bccs
+      @bccs ||=  envelope.bcc.each_with_object([]) do |bcc_user, bccs_array|
+        bccs_array <<  "#{bcc_user.name} <#{bcc_user.mailbox}@#{bcc_user.host}>"
+      end
+    end
+
+    def ccs
+      @ccs ||=  envelope.cc.each_with_object([]) do |cc_user, ccs_array|
+        ccs_array <<  "#{cc_user.name} <#{cc_user.mailbox}@#{cc_user.host}>"
+      end
+    end
+
+    def in_reply_to
+      @in_reply_to ||= envelope.in_reply_to
     end
 
     def <=> (other)
@@ -62,7 +102,6 @@ module WatirmarkEmail
     alias :size :length
 
     def add_emails(email_info)
-      #should be an array of Net::IMAP::FetchData or a single class
       email_info = [email_info] unless email_info.is_a?(Array)
       email_info.each do |email|
         current_email = Email.new

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -22,8 +22,8 @@ module WatirmarkEmail
     end
 
     def tos
-      @tos ||= envelope.to.each_with_object([]) do |recipient, tos_array|
-        tos_array << "#{recipient.mailbox}@#{recipient.host}"
+      @tos ||= envelope.to.each_with_object([]) do |to_user, tos_array|
+        tos_array << "#{to_user.mailbox}@#{to_user.host}"
       end
     end
 

--- a/lib/watirmark_email/email_collection.rb
+++ b/lib/watirmark_email/email_collection.rb
@@ -16,39 +16,27 @@ module WatirmarkEmail
     end
 
     def froms
-      @froms  ||= envelope.from.each_with_object([]) do |from_user, froms_array|
-        froms_array << "#{from_user.mailbox}@#{from_user.host}"
-      end
+      @froms  ||= construct_array_for(envelope.from)
     end
 
     def tos
-      @tos ||= envelope.to.each_with_object([]) do |to_user, tos_array|
-        tos_array << "#{to_user.mailbox}@#{to_user.host}"
-      end
+      @tos ||= construct_array_for(envelope.to)
     end
 
     def reply_tos
-        @reply_tos ||= envelope.reply_to.each_with_object([]) do |reply_to_user, reply_tos_array|
-          reply_tos_array <<  "#{reply_to_user.name} <#{reply_to_user.mailbox}@#{reply_to_user.host}>"
-        end
+        @reply_tos ||= construct_array_for(envelope.reply_to)
     end
 
     def senders
-      @senders ||=  envelope.sender.each_with_object([]) do |sender_user, senders_array|
-        senders_array <<  "#{sender_user.name} <#{sender_user.mailbox}@#{sender_user.host}>"
-      end
+      @senders ||= construct_array_for(envelope.sender)
     end
 
     def bccs
-      @bccs ||= envelope.bcc ? envelope.bcc.each_with_object([]) do |bcc_user, bccs_array|
-        bccs_array <<  "#{bcc_user.name} <#{bcc_user.mailbox}@#{bcc_user.host}>"
-      end : Array.new
+      @bccs ||= construct_array_for(envelope.bcc)
     end
 
     def ccs
-      @ccs ||= envelope.cc ? envelope.cc.each_with_object([]) do |cc_user, ccs_array|
-        ccs_array <<  "#{cc_user.name} <#{cc_user.mailbox}@#{cc_user.host}>"
-      end : Array.new
+      @ccs ||= construct_array_for(envelope.cc)
     end
 
     def in_reply_to
@@ -62,6 +50,17 @@ module WatirmarkEmail
     def has_envelope?
       not envelope.nil?
     end
+
+    private
+
+    def construct_array_for field_values
+      result_array = Array.new
+      field_values.each do |user|
+        result_array <<  "#{user.name} <#{user.mailbox}@#{user.host}>"
+      end
+      result_array
+    end
+
   end
 
   class EmailCollection

--- a/spec/email_base_spec.rb
+++ b/spec/email_base_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'test BaseController helper methods' do
+
+  it "Should convert a hash to an IMAP friendly array" do
+    base_controller = WatirmarkEmail::BaseController.new
+    search_hash = {:subject => 'Test Subject', :reply_to => 'test@devnull.com'}
+    search_array = base_controller.search_hash_to_array(search_hash)
+    search_hash.each_with_index do |key_and_value, index|
+      key = key_and_value.first
+      key_index = index * 2
+      value_index = key_index + 1
+      expect(key.to_s.upcase).to eq(search_array[key_index])
+      expect(search_hash[key]).to eq(search_array[value_index])
+    end
+  end
+
+  it "Should raise an error for improper parameter input" do
+    expect { WatirmarkEmail::BaseController.new.search_hash_to_array("Test") }.to raise_error
+  end
+
+end


### PR DESCRIPTION
This pull request includes a refactoring of email_collection.rb's Email class, which is then used to create email_base.rb's get_email(...) method. 

get_email takes an email model, a set of filter options in the form of a hash, and an optional timeout, then returns an Email object with access to most, if not all, of a desired email's fields. Below is a basic example of it's use:

`desired_email = get_email(email_model, {:subject => subject, :from => from})`
`desired_email.subject`
     => 'Hey'
`desired_email.froms.first`
     => "null@null.com"
`desired_email.tos.first`
     => "sender@null.com"
`desired_email.reply_tos.first`
      =>" Sender sender@null.com"
